### PR TITLE
Modernize Scripts

### DIFF
--- a/close-issues.js
+++ b/close-issues.js
@@ -21,25 +21,25 @@ async function main (args) {
   const [ label, messageFile ] = args
   const message = await readFile(messageFile, 'utf8')
 
-  await fun(process.stdin).pipe(split()).filter(id => id !== '').map(id => Number(id)).forEach(async id => {
+  await fun(process.stdin).filter(id => id !== '').map(id => Number(id)).forEach(async id => {
     await github.issues.addLabels({
-      owner: 'npm',
-      repo: 'npm',
-      number: id,
+      owner: 'SocialStrata',
+      repo: 'crowdstack-pro',
+      issue_number: id,
       labels: [ label ]
     })
     await sleep(4000)
     await github.issues.createComment({
-      owner: 'npm',
-      repo: 'npm',
-      number: id,
+      owner: 'SocialStrata',
+      repo: 'crowdstack-pro',
+      issue_number: id,
       body: message
     })
     await sleep(4000)
-    await github.issues.edit({
-      owner: 'npm',
-      repo: 'npm',
-      number: id,
+    await github.issues.update({
+      owner: 'SocialStrata',
+      repo: 'crowdstack-pro',
+      issue_number: id,
       state: 'closed',
     })
     console.log(id)

--- a/github.js
+++ b/github.js
@@ -1,18 +1,15 @@
 'use strict'
 const fs = require('fs')
 const os = require('os')
-const GitHubApi = require('github')
+const { Octokit } = require("@octokit/rest");
 const Bluebird = require('bluebird')
 
-const github = new GitHubApi({
+const github = new Octokit({
   headers: {
     'user-agent': 'npm gh-issues manager/1.0.0 (support@npmjs.com; https://github.com/npm/gh-issues)'
   },
   Promise: Bluebird,
   timeout: 5000,
-})
-github.authenticate({
-  type: 'token',
-  token: fs.readFileSync(`${os.homedir()}/.gh-issues-token`, 'utf8').trim()
+  auth: fs.readFileSync(`${os.homedir()}/.gh-issues-token`, 'utf8').trim()
 })
 module.exports = github

--- a/list.js
+++ b/list.js
@@ -6,7 +6,6 @@ const prList = fs.createWriteStream('pr-list.ndjson')
 require('./app.js')(main)
 
 function closeStream (stream) {
-  stream.end()
   return new Promise((resolve, reject) => {
     stream.on('error', reject)
     stream.on('close', resolve)
@@ -14,21 +13,14 @@ function closeStream (stream) {
 }
 
 async function main () {
-  let res
-  do {
-    if (res) {
-      res = await github.getNextPage(res)
-    } else {
-      res = await github.issues.getForRepo({
-        owner: 'npm',
-        repo: 'npm',
+  github.paginate(github.rest.issues.listForRepo, {
+    owner: 'SocialStrata',
+        repo: 'crowdstack-pro',
         state: 'open',
         assignee: 'none',
-        milestone: 'none',
         per_page: 100
-      })
-    }
-    const issues = res.data
+  })
+  .then((issues) => {
     issues.forEach(issue => {
       if (issue.pull_request) {
         prList.write(JSON.stringify(issue) + '\n')
@@ -36,6 +28,9 @@ async function main () {
         issueList.write(JSON.stringify(issue) + '\n')
       }
     })
-  } while (github.hasNextPage(res))
-  await Promise.all([closeStream(prList), closeStream(issueList)])
+      prList.end()
+      issueList.end()
+  })
+  .then(Promise.all([closeStream(prList), closeStream(issueList)]));
+
 }

--- a/old-issues.js
+++ b/old-issues.js
@@ -6,21 +6,13 @@ const moment = require('moment')
 const Bluebird = require('bluebird')
 require('./app')(main)
 
-// don't let this filter close issues
-const safeTags = [ 'support', 'npm5' ]
-
 function moreThanDaysAgo (days, date) {
   return moment(date).isBefore(moment().subtract(days, 'days'))
 }
 
 async function main () {
   await fun(fs.createReadStream('issue-list.ndjson')).pipe(ndjson()).filter(issue => {
-    return moreThanDaysAgo(30, issue.updated_at)
-  }).filter(issue => {
-    const labels = issue.labels.map(issue => issue.name)
-    return labels.length && !labels.some(l => safeTags.some(t => t === l))
-  }).filter(issue => {
-    return !/npm[@ ]?[v]?5/.test(issue.title) || !/npm[@ ]?[v]?5/.test(issue.body)
+    return moreThanDaysAgo(180, issue.updated_at)
   }).forEach(issue => {
     console.log(issue.number)
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,2108 +1,518 @@
 {
   "name": "gh-issues",
   "version": "1.0.0",
-  "lockfileVersion": 1,
-  "dependencies": {
-    "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc="
-    },
-    "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-    },
-    "buffer-shims": {
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "follow-redirects": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk="
-    },
-    "funstream": {
-      "version": "file:../funstream",
+      "license": "ISC",
       "dependencies": {
-        "acorn": {
-          "version": "5.0.3",
-          "bundled": true
-        },
-        "acorn-jsx": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dependencies": {
-            "acorn": {
-              "version": "3.3.0",
-              "bundled": true
-            }
-          }
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true
-        },
-        "ajv-keywords": {
-          "version": "1.5.1",
-          "bundled": true
-        },
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "argparse": {
-          "version": "1.0.9",
-          "bundled": true
-        },
-        "array-union": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "array-uniq": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "array.prototype.find": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "babel-code-frame": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "benchmark": {
-          "version": "2.1.4",
-          "bundled": true
-        },
-        "bind-obj-methods": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "bluebird": {
-          "version": "3.5.0",
-          "bundled": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "caller-path": {
-          "version": "0.1.0",
-          "bundled": true
-        },
-        "callsites": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "bundled": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "circular-json": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "clean-yaml-object": {
-          "version": "0.1.0",
-          "bundled": true
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cli-width": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "color-support": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "contains-path": {
-          "version": "0.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "coveralls": {
-          "version": "2.13.1",
-          "bundled": true,
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.3",
-              "bundled": true
-            },
-            "js-yaml": {
-              "version": "3.6.1",
-              "bundled": true
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
-            }
-          }
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true
-        },
-        "d": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "deeper": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "define-properties": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "deglob": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "del": {
-          "version": "2.2.2",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "diff": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "doctrine": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "es-abstract": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "es-to-primitive": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "es5-ext": {
-          "version": "0.10.21",
-          "bundled": true
-        },
-        "es6-iterator": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "es6-map": {
-          "version": "0.1.5",
-          "bundled": true
-        },
-        "es6-set": {
-          "version": "0.1.5",
-          "bundled": true
-        },
-        "es6-symbol": {
-          "version": "3.1.1",
-          "bundled": true
-        },
-        "es6-weak-map": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "escope": {
-          "version": "3.6.0",
-          "bundled": true
-        },
-        "eslint": {
-          "version": "3.19.0",
-          "bundled": true
-        },
-        "eslint-config-standard": {
-          "version": "10.2.1",
-          "bundled": true
-        },
-        "eslint-config-standard-jsx": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "eslint-import-resolver-node": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "eslint-module-utils": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "bundled": true
-            },
-            "ms": {
-              "version": "0.7.1",
-              "bundled": true
-            }
-          }
-        },
-        "eslint-plugin-import": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dependencies": {
-            "doctrine": {
-              "version": "1.5.0",
-              "bundled": true
-            }
-          }
-        },
-        "eslint-plugin-node": {
-          "version": "4.2.2",
-          "bundled": true
-        },
-        "eslint-plugin-promise": {
-          "version": "3.5.0",
-          "bundled": true
-        },
-        "eslint-plugin-react": {
-          "version": "6.10.3",
-          "bundled": true,
-          "dependencies": {
-            "doctrine": {
-              "version": "1.5.0",
-              "bundled": true
-            }
-          }
-        },
-        "eslint-plugin-standard": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "espree": {
-          "version": "3.4.3",
-          "bundled": true
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "esquery": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "esrecurse": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dependencies": {
-            "estraverse": {
-              "version": "4.1.1",
-              "bundled": true
-            }
-          }
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "event-emitter": {
-          "version": "0.3.5",
-          "bundled": true
-        },
-        "events-to-array": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "exit-hook": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "figures": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "file-entry-cache": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "find-root": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "flat-cache": {
-          "version": "1.2.2",
-          "bundled": true
-        },
-        "foreach": {
-          "version": "2.0.5",
-          "bundled": true
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true
-        },
-        "fs-exists-cached": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "function-bind": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "function-loop": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "get-stdin": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true
-        },
-        "globals": {
-          "version": "9.17.0",
-          "bundled": true
-        },
-        "globby": {
-          "version": "5.0.0",
-          "bundled": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "has": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "ignore": {
-          "version": "3.3.3",
-          "bundled": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "inquirer": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "interpret": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "is-callable": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "is-date-object": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-my-json-valid": {
-          "version": "2.16.0",
-          "bundled": true
-        },
-        "is-path-cwd": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-path-in-cwd": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-path-inside": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "is-resolvable": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-symbol": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isexe": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "js-tokens": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "js-yaml": {
-          "version": "3.8.4",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "jsx-ast-utils": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "lcov-parse": {
-          "version": "0.0.10",
-          "bundled": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash.cond": {
-          "version": "4.5.2",
-          "bundled": true
-        },
-        "log-driver": {
-          "version": "1.2.5",
-          "bundled": true
-        },
-        "lru-cache": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dependencies": {
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "minipass": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "mute-stream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "natural-compare": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "nyc": {
-          "version": "10.3.2",
-          "bundled": true,
-          "dependencies": {
-            "align-text": {
-              "version": "0.1.4",
-              "bundled": true
-            },
-            "amdefine": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "append-transform": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "archy": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "arr-flatten": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "arrify": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "async": {
-              "version": "1.5.2",
-              "bundled": true
-            },
-            "babel-code-frame": {
-              "version": "6.22.0",
-              "bundled": true
-            },
-            "babel-generator": {
-              "version": "6.24.1",
-              "bundled": true
-            },
-            "babel-messages": {
-              "version": "6.23.0",
-              "bundled": true
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "bundled": true
-            },
-            "babel-template": {
-              "version": "6.24.1",
-              "bundled": true
-            },
-            "babel-traverse": {
-              "version": "6.24.1",
-              "bundled": true
-            },
-            "babel-types": {
-              "version": "6.24.1",
-              "bundled": true
-            },
-            "babylon": {
-              "version": "6.17.0",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.7",
-              "bundled": true
-            },
-            "braces": {
-              "version": "1.8.5",
-              "bundled": true
-            },
-            "builtin-modules": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "caching-transform": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "camelcase": {
-              "version": "1.2.1",
-              "bundled": true,
-              "optional": true
-            },
-            "center-align": {
-              "version": "0.1.3",
-              "bundled": true,
-              "optional": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true
-            },
-            "cliui": {
-              "version": "2.1.0",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "commondir": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "convert-source-map": {
-              "version": "1.5.0",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "2.4.1",
-              "bundled": true
-            },
-            "cross-spawn": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "debug": {
-              "version": "2.6.6",
-              "bundled": true
-            },
-            "debug-log": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "decamelize": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "default-require-extensions": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "detect-indent": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "error-ex": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "bundled": true
-            },
-            "expand-range": {
-              "version": "1.8.2",
-              "bundled": true
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "filename-regex": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "fill-range": {
-              "version": "2.2.3",
-              "bundled": true
-            },
-            "find-cache-dir": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "for-in": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "for-own": {
-              "version": "0.1.5",
-              "bundled": true
-            },
-            "foreground-child": {
-              "version": "1.5.6",
-              "bundled": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "get-caller-file": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.1",
-              "bundled": true
-            },
-            "glob-base": {
-              "version": "0.3.0",
-              "bundled": true
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "globals": {
-              "version": "9.17.0",
-              "bundled": true
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "handlebars": {
-              "version": "4.0.8",
-              "bundled": true,
-              "dependencies": {
-                "source-map": {
-                  "version": "0.4.4",
-                  "bundled": true
-                }
-              }
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "has-flag": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "hosted-git-info": {
-              "version": "2.4.2",
-              "bundled": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true
-            },
-            "invert-kv": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-arrayish": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "is-buffer": {
-              "version": "1.1.5",
-              "bundled": true
-            },
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-dotfile": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "is-equal-shallow": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "is-extendable": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-finite": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "is-number": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "is-posix-bracket": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "is-primitive": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "is-utf8": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "isobject": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "istanbul-lib-coverage": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "istanbul-lib-hook": {
-              "version": "1.0.6",
-              "bundled": true
-            },
-            "istanbul-lib-instrument": {
-              "version": "1.7.1",
-              "bundled": true
-            },
-            "istanbul-lib-report": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dependencies": {
-                "supports-color": {
-                  "version": "3.2.3",
-                  "bundled": true
-                }
-              }
-            },
-            "istanbul-lib-source-maps": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "istanbul-reports": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "jsesc": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "kind-of": {
-              "version": "3.2.0",
-              "bundled": true
-            },
-            "lazy-cache": {
-              "version": "1.0.4",
-              "bundled": true,
-              "optional": true
-            },
-            "lcid": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "load-json-file": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "longest": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "lru-cache": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "md5-hex": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "md5-o-matic": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "merge-source-map": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.3",
-              "bundled": true
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true
-            },
-            "ms": {
-              "version": "0.7.3",
-              "bundled": true
-            },
-            "normalize-package-data": {
-              "version": "2.3.8",
-              "bundled": true
-            },
-            "normalize-path": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "object.omit": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-locale": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "parse-json": {
-              "version": "2.2.0",
-              "bundled": true
-            },
-            "path-exists": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "path-type": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "pify": {
-              "version": "2.3.0",
-              "bundled": true
-            },
-            "pinkie": {
-              "version": "2.0.4",
-              "bundled": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "pkg-dir": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "preserve": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "pseudomap": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "randomatic": {
-              "version": "1.1.6",
-              "bundled": true
-            },
-            "read-pkg": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "bundled": true
-            },
-            "regex-cache": {
-              "version": "0.4.3",
-              "bundled": true
-            },
-            "remove-trailing-separator": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "repeat-element": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "repeat-string": {
-              "version": "1.6.1",
-              "bundled": true
-            },
-            "repeating": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "require-directory": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "resolve-from": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "right-align": {
-              "version": "0.1.3",
-              "bundled": true,
-              "optional": true
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "bundled": true
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "slide": {
-              "version": "1.1.6",
-              "bundled": true
-            },
-            "source-map": {
-              "version": "0.5.6",
-              "bundled": true
-            },
-            "spawn-wrap": {
-              "version": "1.2.4",
-              "bundled": true,
-              "dependencies": {
-                "signal-exit": {
-                  "version": "2.1.2",
-                  "bundled": true
-                }
-              }
-            },
-            "spdx-correct": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "spdx-expression-parse": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "spdx-license-ids": {
-              "version": "1.2.2",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "test-exclude": {
-              "version": "4.1.0",
-              "bundled": true
-            },
-            "to-fast-properties": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "trim-right": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "uglify-js": {
-              "version": "2.8.22",
-              "bundled": true,
-              "optional": true,
-              "dependencies": {
-                "yargs": {
-                  "version": "3.10.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "which": {
-              "version": "1.2.14",
-              "bundled": true
-            },
-            "which-module": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "window-size": {
-              "version": "0.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "wordwrap": {
-              "version": "0.0.3",
-              "bundled": true
-            },
-            "wrap-ansi": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "write-file-atomic": {
-              "version": "1.3.4",
-              "bundled": true
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "7.1.0",
-              "bundled": true,
-              "dependencies": {
-                "camelcase": {
-                  "version": "3.0.0",
-                  "bundled": true
-                },
-                "cliui": {
-                  "version": "3.2.0",
-                  "bundled": true
-                }
-              }
-            },
-            "yargs-parser": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dependencies": {
-                "camelcase": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "object-keys": {
-          "version": "1.0.11",
-          "bundled": true
-        },
-        "object.assign": {
-          "version": "4.0.4",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "only-shallow": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "opener": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "own-or": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "own-or-env": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "p-limit": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "bundled": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "bundled": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "pkg-conf": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dependencies": {
-            "find-up": {
-              "version": "2.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "pkg-config": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "pkg-up": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "platform": {
-          "version": "1.3.4",
-          "bundled": true
-        },
-        "pluralize": {
-          "version": "1.2.1",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "progress": {
-          "version": "1.1.8",
-          "bundled": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.3.2",
-          "bundled": true
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true
-        },
-        "readline2": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "rechoir": {
-          "version": "0.6.2",
-          "bundled": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "bundled": true
-        },
-        "require-uncached": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "resolve": {
-          "version": "1.3.3",
-          "bundled": true
-        },
-        "resolve-from": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true
-        },
-        "run-async": {
-          "version": "0.1.0",
-          "bundled": true
-        },
-        "run-parallel": {
-          "version": "1.1.6",
-          "bundled": true
-        },
-        "rx-lite": {
-          "version": "3.1.2",
-          "bundled": true
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true
-        },
-        "shelljs": {
-          "version": "0.7.7",
-          "bundled": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "slice-ansi": {
-          "version": "0.0.4",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "bundled": true
-        },
-        "source-map-support": {
-          "version": "0.4.15",
-          "bundled": true
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "stack-utils": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "standard": {
-          "version": "10.0.2",
-          "bundled": true
-        },
-        "standard-engine": {
-          "version": "7.0.0",
-          "bundled": true,
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "table": {
-          "version": "3.8.3",
-          "bundled": true,
-          "dependencies": {
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "tap": {
-          "version": "10.3.2",
-          "bundled": true,
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "tap-mocha-reporter": {
-          "version": "3.0.3",
-          "bundled": true
-        },
-        "tap-parser": {
-          "version": "5.3.3",
-          "bundled": true
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "through": {
-          "version": "2.3.8",
-          "bundled": true
-        },
-        "tmatch": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true
-        },
-        "trivial-deferred": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "tryit": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "bundled": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "bundled": true
-        },
-        "unicode-length": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "uniq": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true
-        },
-        "which": {
-          "version": "1.2.14",
-          "bundled": true,
-          "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "write": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "yapool": {
-          "version": "1.0.0",
-          "bundled": true
-        }
+        "@octokit/rest": "^18.5.2",
+        "bluebird": "^3.5.0",
+        "funstream": "^4.2.0",
+        "moment": "^2.18.1",
+        "ndjson": "^1.5.0",
+        "signal-exit": "^3.0.2",
+        "split": "^1.0.0"
       }
     },
-    "github": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/github/-/github-9.2.0.tgz",
-      "integrity": "sha1-iohtxA3WNjZwfcr5nfPfJsWfFvw="
+    "node_modules/@octokit/auth-token": {
+      "version": "2.4.5",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
     },
-    "https-proxy-agent": {
+    "node_modules/@octokit/core": {
+      "version": "3.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.11",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "6.0.0",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.13.3",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.11.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.13.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.4.14",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.7.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "18.5.2",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.13.0",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^6.0.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.1",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bluebird": {
+      "version": "3.5.0",
+      "license": "MIT"
+    },
+    "node_modules/buffer-shims": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY="
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "license": "ISC"
+    },
+    "node_modules/funstream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/funstream/-/funstream-4.2.0.tgz",
+      "integrity": "sha512-oeca9NjlPNa3kspUF90NEJJcPVSqiiP4zRIZ+wv9B6bWSBfUwCR+RuBbKfqSbw+3674Aqk4/3AByBvnTfigf6A==",
+      "dependencies": {
+        "isa-stream": "^1.1.3"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "license": "ISC"
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isa-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/isa-stream/-/isa-stream-1.1.3.tgz",
+      "integrity": "sha512-wJjmZRMJ3cBfb8kb1aBgT00aEhHJDRZ4x8A4B5p06v1u+ryB4WKYP0jacmLG0Ktnk9bwLetcwHoKui7dLojEeA=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "license": "ISC"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.0",
+      "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.18.1",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ndjson": {
+      "version": "1.5.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
+      },
+      "bin": {
+        "ndjson": "cli.js"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "1.0.7",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.2.9",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.0.1",
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.2",
+      "license": "ISC"
+    },
+    "node_modules/split": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/split2": {
+      "version": "2.1.1",
+      "license": "ISC",
+      "dependencies": {
+        "through2": "^2.0.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "license": "ISC"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  },
+  "dependencies": {
+    "@octokit/auth-token": {
+      "version": "2.4.5",
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.4.0",
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.11",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.6.1",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "6.0.0"
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.13.3",
+      "requires": {
+        "@octokit/types": "^6.11.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.3",
+      "requires": {}
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.0.0",
+      "requires": {
+        "@octokit/types": "^6.13.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.14",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.7.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.5",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.5.2",
+      "requires": {
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.13.0",
+      "requires": {
+        "@octokit/openapi-types": "^6.0.0"
+      }
+    },
+    "before-after-hook": {
+      "version": "2.2.1"
+    },
+    "bluebird": {
+      "version": "3.5.0"
+    },
+    "buffer-shims": {
+      "version": "1.0.0"
+    },
+    "core-util-is": {
+      "version": "1.0.2"
+    },
+    "deprecation": {
+      "version": "2.3.1"
+    },
+    "funstream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/funstream/-/funstream-4.2.0.tgz",
+      "integrity": "sha512-oeca9NjlPNa3kspUF90NEJJcPVSqiiP4zRIZ+wv9B6bWSBfUwCR+RuBbKfqSbw+3674Aqk4/3AByBvnTfigf6A==",
+      "requires": {
+        "isa-stream": "^1.1.3"
+      }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.3"
+    },
+    "is-plain-object": {
+      "version": "5.0.0"
+    },
+    "isa-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/isa-stream/-/isa-stream-1.1.3.tgz",
+      "integrity": "sha512-wJjmZRMJ3cBfb8kb1aBgT00aEhHJDRZ4x8A4B5p06v1u+ryB4WKYP0jacmLG0Ktnk9bwLetcwHoKui7dLojEeA=="
     },
     "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "version": "1.0.0"
     },
     "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "mime": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+      "version": "5.0.1"
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.0"
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.18.1"
     },
     "ndjson": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
-      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg="
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
+      }
     },
-    "netrc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
-      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
+    "node-fetch": {
+      "version": "2.6.1"
+    },
+    "once": {
+      "version": "1.4.0",
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "1.0.7"
     },
     "readable-stream": {
       "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g="
+      "requires": {
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-    },
-    "semver": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-      "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+      "version": "5.0.1"
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "3.0.2"
     },
     "split": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64="
+      "requires": {
+        "through": "2"
+      }
     },
     "split2": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-      "integrity": "sha1-eh9VHhdqkOzTNF9yRqDP4XXvT9A="
-    },
-    "stream-consume": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-      "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
+      "requires": {
+        "through2": "^2.0.2"
+      }
     },
     "string_decoder": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "version": "2.3.8"
     },
     "through2": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
+      "requires": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      }
+    },
+    "universal-user-agent": {
+      "version": "6.0.0"
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "version": "1.0.2"
+    },
+    "wrappy": {
+      "version": "1.0.2"
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "author": "Rebecca Turner <me@re-becca.org> (http://re-becca.org/)",
   "license": "ISC",
   "dependencies": {
+    "@octokit/rest": "^18.5.2",
     "bluebird": "^3.5.0",
-    "funstream": "file:../funstream",
-    "github": "^9.2.0",
+    "funstream": "^4.2.0",
     "moment": "^2.18.1",
     "ndjson": "^1.5.0",
     "signal-exit": "^3.0.2",


### PR DESCRIPTION
* Updated the old github dependency to the proper @octokit/rest.
* Added funstream as a formal dependency, rather than a local, relative dependency.
* Updated the owner and repo to SocialStrata/crowdstack-pro so we can run against our repo.
* Fixed close-issues.js so that it works now. Had to update a few different things to get things working with the latest funstream and octokit/rest APIs.
* Fixed the Octokit auth in github.js.
* Fixed the pagination strategy in list.js and reorganized how the streams are closed.
* Removed some label and title/body filtering in old-issues.js that we don't care about.
* Changed old-issues.js to close anything that hasn't been updated for 180 days instead of 30.